### PR TITLE
fix: Debian package arch in filename

### DIFF
--- a/roles/ricochet_server/tasks/systemd.yml
+++ b/roles/ricochet_server/tasks/systemd.yml
@@ -1,6 +1,11 @@
 - name: Set package filename (Debian)
   ansible.builtin.set_fact:
-    _ricochet_pkg_filename: "ricochet-server_{{ ricochet_version }}-1_{{ ansible_facts['dpkg_arch'] | default(ansible_facts['architecture']) }}.deb"
+    _ricochet_pkg_filename: >-
+      ricochet-server_{{ ricochet_version }}-1_{{
+      (ansible_facts['dpkg_arch'] | default(ansible_facts['architecture']))
+      | regex_replace('^x86_64$', 'amd64')
+      | regex_replace('^aarch64$', 'arm64')
+      }}.deb
   when: ansible_facts['os_family'] == "Debian"
 
 - name: Set package filename (RedHat)


### PR DESCRIPTION
## Summary
- normalize Debian package architecture names when building `.deb` filename
- map `x86_64 -> amd64`
- map `aarch64 -> arm64`

## Why
On Debian hosts where `ansible_facts['dpkg_arch']` is absent, the role fell back to `ansible_facts['architecture']` (for example `x86_64`) and generated:

`ricochet-server_<version>-1_x86_64.deb`

That file does not exist in the package bucket (uses Debian naming like `amd64`), causing a 404 during download.

## Scope
- only adjusts Debian filename construction in `roles/ricochet_server/tasks/systemd.yml`
- no changes to service behavior or docker mode
