### PR TITLE
fix: handle --check mode in systemd package install

### DIFF
--- a/roles/ricochet_server/tasks/systemd.yml
+++ b/roles/ricochet_server/tasks/systemd.yml
@@ -18,6 +18,8 @@
     url: '{{ ricochet_package_url_base }}/{{ ricochet_version }}/{{ _ricochet_pkg_filename }}'
     dest: '/tmp/{{ _ricochet_pkg_filename }}'
     mode: '0644'
+  # Always download so the install task has a real RPM/DEB to inspect in --check mode.
+  check_mode: false
   when: ricochet_deploy
 
 - name: Install ricochet-server package (Debian)
@@ -89,4 +91,6 @@
   ansible.builtin.file:
     path: '/tmp/{{ _ricochet_pkg_filename }}'
     state: absent
+  # Mirror the download above so --check leaves no artifacts behind.
+  check_mode: false
   when: ricochet_deploy


### PR DESCRIPTION
In --check mode, ansible.builtin.get_url skips the actual download but the subsequent local-file dnf/apt install still runs in check mode and needs the file present to inspect the package.
Without the file the install task fails with "Could not open" / "no such file" before reporting what would change.

Force the download to run in check mode as well, and mirror the same override on the cleanup task so --check leaves no leftover RPM/DEB in /tmp.